### PR TITLE
Update offset_int to match XLook

### DIFF
--- a/pylook/calc/basic.py
+++ b/pylook/calc/basic.py
@@ -62,7 +62,7 @@ def zero(data, zero_idx, window=0, value=0, mode='at'):
 
 
 @exporter.export
-def remove_offset(data, start_idx, end_idx):
+def remove_offset(data, start_idx, end_idx, set_between=False):
     """
     Remove offsets in the data.
 
@@ -74,6 +74,9 @@ def remove_offset(data, start_idx, end_idx):
         Index that marks the start of the offset.
     end_idx : int
         Index that marks the end of the offset.
+    set_between : int
+        Set the data after the start point up to the end point to have the
+        value of the start point. Default is `False`.
 
     Returns
     -------
@@ -82,8 +85,13 @@ def remove_offset(data, start_idx, end_idx):
     """
     # Set the data after the offset to the data minus the offset
     offset = data[end_idx] - data[start_idx]
-    data[start_idx + 1:] = data[start_idx + 1:] - offset
-    data[start_idx: end_idx + 1] = data[start_idx]
+
+    # Set the intemediate data (during the offset) to be the first
+    # value if so desired.
+    if set_between:
+        data[start_idx: end_idx] = data[start_idx]
+
+    data[end_idx:] = data[end_idx:] - offset
     return data
 
 

--- a/tests/calc/test_basic.py
+++ b/tests/calc/test_basic.py
@@ -94,6 +94,17 @@ def test_remove_offset():
 
     result = remove_offset(data, 4, 6)
 
+    truth = np.array([0, 1, 2, 4, 4, 10, 4, 5, 6, 7, 8]) * units('mm')
+
+    assert_array_almost_equal(result, truth)
+
+
+def test_remove_offset_set_between():
+    """Test the remove offset function."""
+    data = np.array([0, 1, 2, 4, 4, 10, 10, 11, 12, 13, 14]) * units('mm')
+
+    result = remove_offset(data, 4, 6, set_between=True)
+
     truth = np.array([0, 1, 2, 4, 4, 4, 4, 5, 6, 7, 8]) * units('mm')
 
     assert_array_almost_equal(result, truth)


### PR DESCRIPTION
XLook had the capability to reset (or not) the values in the interval of the offset. We're matching that functionality.

Closes #13